### PR TITLE
Allow Cross-Origin resource sharing

### DIFF
--- a/Server/CBXCUITestServer.m
+++ b/Server/CBXCUITestServer.m
@@ -50,6 +50,10 @@ static NSString *serverName = @"CalabashXCUITestServer";
         [_server setRouteQueue:dispatch_get_main_queue()];
         [_server setDefaultHeader:@"CalabusDriver"
                                         value:@"CalabashXCUITestServer/1.0"];
+        [_server setDefaultHeader:@"Access-Control-Allow-Origin"
+                                        value:@"*"];
+        [_server setDefaultHeader:@"Access-Control-Allow-Headers"
+                                        value:@"Content-Type, X-Requested-With"];
         [_server setConnectionClass:[RoutingConnection self]];
         [_server setType:@"_calabus._tcp."];
 

--- a/Server/Routes/CBXRoute.h
+++ b/Server/Routes/CBXRoute.h
@@ -54,5 +54,12 @@ Object containing logic for an HTTP route.
  @param block Block to execude when requests are matched to this route
  */
 + (instancetype)delete:(NSString *)path withBlock:(RequestHandler)block;
+
+/**
+ Convenience constructor for a OPTIONS route
+ @param path Route path regex
+ @param block Block to execude when requests are matched to this route
+ */
++ (instancetype)options:(NSString *)path withBlock:(RequestHandler)block;
 @end
  

--- a/Server/Routes/CBXRoute.m
+++ b/Server/Routes/CBXRoute.m
@@ -51,6 +51,9 @@
 + (instancetype)delete:(NSString *)path withBlock:(RequestHandler)block {
     return [self http:@"DELETE" path:path withBlock:block];
 }
++ (instancetype)options:(NSString *)path withBlock:(RequestHandler)block {
+    return [self http:@"OPTIONS" path:path withBlock:block];
+}
 
 - (NSString *)description {
     return [NSString stringWithFormat:@"%@ %@", self.HTTPVerb, self.path];

--- a/Server/Routes/UndefinedRoutes.m
+++ b/Server/Routes/UndefinedRoutes.m
@@ -30,11 +30,17 @@
                                      @"requestBody" : body ?: @{}
          }];
     };
+
+    RequestHandler pingBlock = ^(RouteRequest *request, NSDictionary *body, RouteResponse *response) {
+        [response setStatusCode:200];
+    };
+
     return @[
              [CBXRoute get:@"/*" withBlock:unhandledBlock].dontAutoregister,
              [CBXRoute post:@"/*" withBlock:unhandledBlock].dontAutoregister,
              [CBXRoute put:@"/*" withBlock:unhandledBlock].dontAutoregister,
              [CBXRoute delete:@"/*" withBlock:unhandledBlock].dontAutoregister,
+             [CBXRoute options:@"/*" withBlock:pingBlock].dontAutoregister,
              ];
 }
 @end


### PR DESCRIPTION
Allowing Cross-Origin resource sharing makes it possible to use web-based UI elements inspector