### PR TITLE
[Support] Fix identifier implicit assertion issue in debug log

### DIFF
--- a/Server/Application/Application.m
+++ b/Server/Application/Application.m
@@ -98,7 +98,7 @@ static Application *currentApplication;
 + (XCUIApplicationState)terminateApplication:(XCUIApplication *)application {
     NSTimeInterval startTime = [[CBXMachClock sharedClock] absoluteTime];
     if (application.state == XCUIApplicationStateNotRunning) {
-        DDLogDebug(@"Application %@ is not running", application.identifier);
+        DDLogDebug(@"Application %@ is not running", application.bundleID);
         return XCUIApplicationStateNotRunning;
     }
 


### PR DESCRIPTION
Fix 2 issues:
1. null in debug log: "Application (null) is not running"
2. implicit assertion issues: "DeviceAgent-Runner[13550:427853] 2020-06-04 13:21:00.285 DEBUG RoutingHTTPServer:225 | DELETE /1.0/session 
    t =    48.42s Find the Application 'com.my.app.dev'
    t =    48.43s     Collecting extra data to assist test failure triage
    t =    48.54s     Assertion Failure: Application.m:101: Failed to get matching snapshot: Application com.my.app.dev is not running"